### PR TITLE
security: load Cloudinary credentials from environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Cloudinary credentials — required for client-side upload signing.
+# These are read from the environment at BUILD time (inlined by
+# babel-plugin-transform-inline-environment-variables), not at runtime.
+#
+# Local dev:   export them in your shell before running Metro, e.g.
+#   CLOUDINARY_API_KEY=xxx CLOUDINARY_API_SECRET=yyy npm run android
+# Production:  set them in your build environment / CI secrets.
+#
+# Copy this file to `.env` only if you use a dotenv loader; the values below
+# must NOT be committed.
+CLOUDINARY_API_KEY=
+CLOUDINARY_API_SECRET=

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,11 @@ buck-out/
 # Bundle artifact
 *.jsbundle
 
+# Local environment files (never commit secrets)
+.env
+.env.local
+.env.*.local
+
 # CocoaPods
 /ios/Pods/
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,17 @@ cd ios && pod install && cd ..
 
 ### Configure
 
-There is no `.env` file. Open `config/config.js` and set the `mode` (`dev` / `herokudev` / `prod`) to pick the backend URL, and supply your Cloudinary credentials and upload preset before building.
+The backend URL and Cloudinary upload preset are selected by the `mode` switch (`dev` / `herokudev` / `prod`) in `config/config.js`.
+
+Cloudinary **credentials are read from the environment at build time** (inlined by `babel-plugin-transform-inline-environment-variables`) and are never committed to the repo. Provide them before building — see `.env.example`:
+
+```bash
+CLOUDINARY_API_KEY=your_key CLOUDINARY_API_SECRET=your_secret npm run android
+```
+
+In production, set `CLOUDINARY_API_KEY` and `CLOUDINARY_API_SECRET` in your build environment / CI secrets.
+
+> Note: this app signs Cloudinary uploads on the client, so these credentials are inlined into the shipped bundle and can still be extracted from a built app. Moving signing to a backend endpoint (see Future scope) is the durable fix; the environment change here removes the secrets from source control.
 
 ### Run
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,6 @@
 module.exports = {
   presets: ['module:metro-react-native-babel-preset'],
+  // Inline CLOUDINARY_API_KEY / CLOUDINARY_API_SECRET (and any other process.env.*
+  // references) from the build environment so secrets are never committed to source.
+  plugins: ['transform-inline-environment-variables'],
 };

--- a/config/config.js
+++ b/config/config.js
@@ -61,8 +61,11 @@ export default {
     userDetails: 'user',
   },
   cloudinary: {
-    apiKey: '851184338949628',
-    apiSecret: '0sIXpYfKjBO9XlDvX9AnZHvOLKw',
+    // Secrets are injected from the environment at build time via
+    // babel-plugin-transform-inline-environment-variables. Set CLOUDINARY_API_KEY
+    // and CLOUDINARY_API_SECRET in your environment before building (see .env.example).
+    apiKey: process.env.CLOUDINARY_API_KEY,
+    apiSecret: process.env.CLOUDINARY_API_SECRET,
     secureDeliveryURL: 'https://res.cloudinary.com/harshdeep-singh/image/upload/',
     apiURL: 'https://api.cloudinary.com/v1_1/harshdeep-singh/',
     uploadPreset: `pixeliano_preset_${mode}`,

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@babel/runtime": "^7.6.2",
     "@react-native-community/eslint-config": "^0.0.5",
     "babel-jest": "^24.9.0",
+    "babel-plugin-transform-inline-environment-variables": "^0.4.4",
     "eslint": "^6.5.1",
     "jest": "^24.9.0",
     "metro-react-native-babel-preset": "^0.56.0",


### PR DESCRIPTION
## What

The Cloudinary **API key and secret were hardcoded** in `config/config.js` and committed to this public repo. This change removes them and reads them from the environment instead.

- `config/config.js` — `apiKey`/`apiSecret` now come from `process.env.CLOUDINARY_API_KEY` / `process.env.CLOUDINARY_API_SECRET`.
- `babel.config.js` — adds `babel-plugin-transform-inline-environment-variables`, which inlines those env vars at **build time** (React Native has no runtime `process.env`).
- `package.json` — adds the plugin as a devDependency.
- `.env.example` — documents the two variables; `.gitignore` now excludes `.env`.
- `README.md` — Configure section updated for the env-based setup.

Usage (local): `CLOUDINARY_API_KEY=xxx CLOUDINARY_API_SECRET=yyy npm run android`. Production: set them in the build environment / CI secrets.

## ⚠️ Required follow-up: rotate the keys

The old key/secret remain in this repo's **git history** (and were public), so they must be considered compromised. **Rotate/regenerate the Cloudinary API secret in the Cloudinary console** — removing them from the current file does not invalidate the exposed ones.

## Caveat (not addressed here)

This app signs Cloudinary uploads **on the client**, so even via env vars the secret is inlined into the shipped bundle and can be extracted from a built app. The durable fix is moving upload signing to a backend endpoint (already noted in the README's Future scope).

## Verification note

I could not run the React Native build in this environment. Please `npm install` and do a build (`npm run android`/`ios`) to confirm the inlined env vars resolve before merging.